### PR TITLE
Adição de informações no retorno Praça/Parceiros

### DIFF
--- a/atividades/serializers.py
+++ b/atividades/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from pracas.serializers import PracaListSerializer
 from .models import Agenda
 from .models import Ocorrencia
 from .models import Relatorio
@@ -48,6 +49,7 @@ class OcorrenciaSerializer(serializers.ModelSerializer):
 class AgendaDetailSerializer(serializers.ModelSerializer):
     url = serializers.SerializerMethodField(read_only=True)
     ocorrencia = OcorrenciaSerializer()
+    praca_detail = PracaListSerializer(source='praca',read_only=True)
 
     def get_url(self, obj):
         return obj.get_absolute_url()

--- a/pracas/serializers.py
+++ b/pracas/serializers.py
@@ -186,7 +186,7 @@ class AtorDetailSerializer(serializers.ModelSerializer):
 
 class PracaSerializer(PracaBaseSerializer):
     imagem = ImagemPracaSerializer(many=True, read_only=True)
-    parceiros = ParceiroListSerializer(many=True, read_only=True)
+    parceiros = ParceiroDetailSerializer(many=True, read_only=True)
     unidade_gestora = MembroUglSerializer(
         source='ugl', many=True, read_only=True)
     rh = RhListSerializer(source='get_rh_ativos', many=True, read_only=True)


### PR DESCRIPTION
Foi alterado de ParceirosListSerializer para ParceiroDetailSerializer para o retorno da AIP de consulta da PraçaSerializer.

Atendendo a requisição da Issue #21 