### PR TITLE
Altera o filtro de saida do endpoint de RH de uma Praça

### DIFF
--- a/pracas/views.py
+++ b/pracas/views.py
@@ -267,7 +267,7 @@ class RhViewSet(DefaultMixin, ModelViewSet):
     def list(self, request, praca_pk=None):
         praca = get_object_or_404(Praca, pk=praca_pk)
 
-        rhs = Rh.objects.filter(praca=praca, data_saida=None)
+        rhs = Rh.objects.filter(praca=praca)
         serializer = RhDetailSerializer(rhs, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
Altera o filtro para incluir TODOS os registro de recursos humanos
de uma Praça, independente de sua situação com a mesma.

Co-authored-by: leo <volthier@gmail.com>