### PR TITLE
[UPDATE] Atualiza o Django para 1.11.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.1
+Django==1.11.10
 psycopg2==2.7.1
 
 sqlparse==0.1.13


### PR DESCRIPTION
Atualiza o Django para versão 1.11.10 a fim de corrigir falhas de segurança sem quebrar a compatibilidade com a plataforma atual.

Para maiores informações: https://docs.djangoproject.com/en/2.0/releases/1.11.10/