### PR TITLE
Fix edit info praca

### DIFF
--- a/pracas/permissions.py
+++ b/pracas/permissions.py
@@ -7,8 +7,8 @@ from rest_framework.compat import is_authenticated
 class IsAdminOrManagerOrReadOnly(BasePermission):
     """
     Permite leitura de qualquer usuário e permite a atualização de informações
-    por administradores e gestores de Praça e a adição de novas instancias por
-    administradores.
+    por administradores MinC e a adição de novas instancias por administradores MinC.
+    Exclusivo para administradores MinC.
     """
 
     def __init__(self):
@@ -37,8 +37,8 @@ class IsAdminOrManagerOrReadOnly(BasePermission):
 
 class IsOwnerOrReadOnly(BasePermission):
     """
-    Permite leitura por qualquer usuário, mas administradores e gestores de
-    Praça podem adicionar novas instancias.
+    Mesmas permissões que o IsAdminOrManagerOrReadOnly, porém mais permissivo 
+    para englobar também o gestor da praça
     """
 
     def __init__(self):

--- a/pracas/views.py
+++ b/pracas/views.py
@@ -43,7 +43,7 @@ from .permissions import IsOwnerOrReadOnly
 class PracaViewSet(DefaultMixin, MultiSerializerViewSet):
 
     authentication_classes = (JSONWebTokenAuthentication, )
-    permission_classes = (IsAdminOrManagerOrReadOnly, )
+    permission_classes = (IsOwnerOrReadOnly, )
 
     metadata_class = ChoicesMetadata
     serializer_class = PracaSerializer


### PR DESCRIPTION
Anteriormente o gestor da praça não tinha permissão para editar as informações da CEU em si
Melhoria da documentação das permissões